### PR TITLE
Refactor: JPA 엔티티 새롭게 정의, DB 설정 수정 및 의존성 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'com.mysql:mysql-connector-j:8.4.0'
+//    runtimeOnly 'org.postgresql:postgresql'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/application/getinitline/config/JpaConfig.java
+++ b/src/main/java/com/application/getinitline/config/JpaConfig.java
@@ -12,8 +12,8 @@ import org.springframework.transaction.PlatformTransactionManager;
 
 import javax.sql.DataSource;
 
-@EnableJpaAuditing
-@Configuration
+//@EnableJpaAuditing
+//@Configuration
 public class JpaConfig {
 
  //  @Bean
@@ -30,61 +30,61 @@ public class JpaConfig {
 //
 //  }
 // Properties에서 설정에서 자바코드로 설정하는 방법
- @ConfigurationProperties("spring.datasource")
- @Bean
- public DataSource dataSource() {
-  return DataSourceBuilder.create().build(); // Config.properties 파일의 설정을 읽어들인다.
- }
-
- @Bean
- public DataSource dataSource2() {
-  return DataSourceBuilder.create().build(); // Config.properties 파일의 설정을 읽어들인다.
- }
-
- @Bean
- public LocalContainerEntityManagerFactoryBean entityManagerFactory(DataSource dataSource) {
-
-  HibernateJpaVendorAdapter vendorAdapter = new HibernateJpaVendorAdapter();
-  vendorAdapter.setGenerateDdl(true);
-
-  LocalContainerEntityManagerFactoryBean factory = new LocalContainerEntityManagerFactoryBean();
-  factory.setJpaVendorAdapter(vendorAdapter);
-  factory.setPackagesToScan("com.application.getinitline");
-//   factory.setDataSource(dataSource);
-  factory.setDataSource(dataSource());
-  return factory;
- }
-
- @Bean
- public LocalContainerEntityManagerFactoryBean entityManagerFactory2(DataSource dataSource) {
-
-  HibernateJpaVendorAdapter vendorAdapter = new HibernateJpaVendorAdapter();
-  vendorAdapter.setGenerateDdl(true);
-
-  LocalContainerEntityManagerFactoryBean factory = new LocalContainerEntityManagerFactoryBean();
-  factory.setJpaVendorAdapter(vendorAdapter);
-  factory.setPackagesToScan("com.application.getinitline");
-//   factory.setDataSource(dataSource);
-  factory.setDataSource(dataSource());
-  return factory;
- }
-
- @Bean
- public PlatformTransactionManager transactionManager(EntityManagerFactory entityManagerFactory) {
-
-  JpaTransactionManager txManager = new JpaTransactionManager();
-  txManager.setEntityManagerFactory(entityManagerFactory);
-  return txManager;
- }
-
- @Bean
- public PlatformTransactionManager transactionManager2(EntityManagerFactory entityManagerFactory) {
-
-  JpaTransactionManager txManager = new JpaTransactionManager();
-  txManager.setEntityManagerFactory(entityManagerFactory);
-  return txManager;
- }
-
+// @ConfigurationProperties("spring.datasource")
 // @Bean
-// public ChaninedTransactionManager transactionManager(PlatformTransactionManager transactionManager1, PlatformTransactionManager transactionManager2) {}
+// public DataSource dataSource() {
+//  return DataSourceBuilder.create().build(); // Config.properties 파일의 설정을 읽어들인다.
+// }
+//
+// @Bean
+// public DataSource dataSource2() {
+//  return DataSourceBuilder.create().build(); // Config.properties 파일의 설정을 읽어들인다.
+// }
+//
+// @Bean
+// public LocalContainerEntityManagerFactoryBean entityManagerFactory(DataSource dataSource) {
+//
+//  HibernateJpaVendorAdapter vendorAdapter = new HibernateJpaVendorAdapter();
+//  vendorAdapter.setGenerateDdl(true);
+//
+//  LocalContainerEntityManagerFactoryBean factory = new LocalContainerEntityManagerFactoryBean();
+//  factory.setJpaVendorAdapter(vendorAdapter);
+//  factory.setPackagesToScan("com.application.getinitline");
+////   factory.setDataSource(dataSource);
+//  factory.setDataSource(dataSource());
+//  return factory;
+// }
+//
+// @Bean
+// public LocalContainerEntityManagerFactoryBean entityManagerFactory2(DataSource dataSource) {
+//
+//  HibernateJpaVendorAdapter vendorAdapter = new HibernateJpaVendorAdapter();
+//  vendorAdapter.setGenerateDdl(true);
+//
+//  LocalContainerEntityManagerFactoryBean factory = new LocalContainerEntityManagerFactoryBean();
+//  factory.setJpaVendorAdapter(vendorAdapter);
+//  factory.setPackagesToScan("com.application.getinitline");
+////   factory.setDataSource(dataSource);
+//  factory.setDataSource(dataSource());
+//  return factory;
+// }
+//
+// @Bean
+// public PlatformTransactionManager transactionManager(EntityManagerFactory entityManagerFactory) {
+//
+//  JpaTransactionManager txManager = new JpaTransactionManager();
+//  txManager.setEntityManagerFactory(entityManagerFactory);
+//  return txManager;
+// }
+//
+// @Bean
+// public PlatformTransactionManager transactionManager2(EntityManagerFactory entityManagerFactory) {
+//
+//  JpaTransactionManager txManager = new JpaTransactionManager();
+//  txManager.setEntityManagerFactory(entityManagerFactory);
+//  return txManager;
+// }
+//
+//// @Bean
+//// public ChaninedTransactionManager transactionManager(PlatformTransactionManager transactionManager1, PlatformTransactionManager transactionManager2) {}
 }

--- a/src/main/java/com/application/getinitline/domain/Admin.java
+++ b/src/main/java/com/application/getinitline/domain/Admin.java
@@ -1,30 +1,96 @@
 package com.application.getinitline.domain;
 
-import lombok.Data;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import java.time.LocalDateTime;
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Set;
 
-import java.time.LocalDate;
-import java.time.LocalTime;
+@Getter
+@ToString
+@Table(indexes = {
+    @Index(columnList = "phoneNumber"),
+    @Index(columnList = "createdAt"),
+    @Index(columnList = "modifiedAt")
+})
+@EntityListeners(AuditingEntityListener.class)
+@Entity
+public class Admin {
 
-/**
- * packageName    : com.application.getinitline.domain
- * fileName       : Admin
- * author         : NAHAEJUN
- * date           : 2025-02-26
- * description    :
- * ===========================================================
- * DATE              AUTHOR             NOTE
- * -----------------------------------------------------------
- * 2025-02-26        NAHAEJUN              최초생성
- */
-@Data
- public class Admin {
-    private Long id;
-    private String name;
-    private String nickname;
-    private String password;
-    private String phoneNumber;
-    private String memo;
+   @Id
+   @GeneratedValue(strategy = GenerationType.IDENTITY)
+   private Long id;
 
-    private LocalDate createdAt;
-    private LocalTime modifiedAt;
+
+   @Setter
+   @Column(nullable = false, unique = true)
+   private String email;
+
+   @Setter
+   @Column(nullable = false, unique = true)
+   private String nickname;
+
+   @Setter
+   @Column(nullable = false)
+   private String password;
+
+   @Setter
+   @Column(nullable = false)
+   private String phoneNumber;
+
+
+   @Setter
+   private String memo;
+
+
+   @ToString.Exclude
+   @OrderBy("id")
+   @OneToMany(mappedBy = "admin")
+   private final Set<AdminPlaceMap> adminPlaceMaps = new LinkedHashSet<>();
+
+
+   @Column(nullable = false, insertable = false, updatable = false,
+       columnDefinition = "datetime default CURRENT_TIMESTAMP")
+   @CreatedDate
+   private LocalDateTime createdAt;
+
+   @Column(nullable = false, insertable = false, updatable = false,
+       columnDefinition = "datetime default CURRENT_TIMESTAMP on update CURRENT_TIMESTAMP")
+   @LastModifiedDate
+   private LocalDateTime modifiedAt;
+
+
+   protected Admin() {}
+
+   protected Admin(String email, String nickname, String password, String phoneNumber, String memo) {
+      this.email = email;
+      this.nickname = nickname;
+      this.password = password;
+      this.phoneNumber = phoneNumber;
+      this.memo = memo;
+   }
+
+   public static Admin of(String email, String nickname, String password, String phoneNumber, String memo) {
+      return new Admin(email, nickname, password, phoneNumber, memo);
+   }
+
+
+   @Override
+   public boolean equals(Object obj) {
+      if (this == obj) return true;
+      if (obj == null || getClass() != obj.getClass()) return false;
+      return id != null && id.equals(((Admin) obj).getId());
+   }
+
+   @Override
+   public int hashCode() {
+      return Objects.hash(email, nickname, phoneNumber, createdAt, modifiedAt);
+   }
+
 }

--- a/src/main/java/com/application/getinitline/domain/AdminPlaceMap.java
+++ b/src/main/java/com/application/getinitline/domain/AdminPlaceMap.java
@@ -1,26 +1,72 @@
 package com.application.getinitline.domain;
 
-import lombok.Data;
-
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import java.time.LocalDateTime;
+import java.util.Objects;
 
-/**
- * packageName    : com.application.getinitline.domain
- * fileName       : AdminPlaceMap
- * author         : NAHAEJUN
- * date           : 2025-02-26
- * description    :
- * ===========================================================
- * DATE              AUTHOR             NOTE
- * -----------------------------------------------------------
- * 2025-02-26        NAHAEJUN              최초생성
- */
-@Data
+@Getter
+@ToString
+@Table(indexes = {
+    @Index(columnList = "createdAt"),
+    @Index(columnList = "modifiedAt")
+})
+@EntityListeners(AuditingEntityListener.class)
+@Entity
 public class AdminPlaceMap {
-    private Long id;
-    private Long adminId;
-    private Long PlaceId;
 
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+
+    @Setter
+    @ManyToOne(optional = false)
+    private Admin admin;
+
+    @Setter
+    @ManyToOne(optional = false)
+    private Place place;
+
+
+    @Column(nullable = false, insertable = false, updatable = false,
+        columnDefinition = "datetime default CURRENT_TIMESTAMP")
+    @CreatedDate
     private LocalDateTime createdAt;
+
+    @Column(nullable = false, insertable = false, updatable = false,
+        columnDefinition = "datetime default CURRENT_TIMESTAMP on update CURRENT_TIMESTAMP")
+    @LastModifiedDate
     private LocalDateTime modifiedAt;
+
+
+    protected AdminPlaceMap() {}
+
+    protected AdminPlaceMap(Admin admin, Place place) {
+        this.admin = admin;
+        this.place = place;
+    }
+
+    public static AdminPlaceMap of(Admin admin, Place place) {
+        return new AdminPlaceMap(admin, place);
+    }
+
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (obj == null || getClass() != obj.getClass()) return false;
+        return id != null && id.equals(((AdminPlaceMap) obj).getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(place, admin, createdAt, modifiedAt);
+    }
+
 }

--- a/src/main/java/com/application/getinitline/domain/Event.java
+++ b/src/main/java/com/application/getinitline/domain/Event.java
@@ -1,34 +1,138 @@
 package com.application.getinitline.domain;
 
 import com.application.getinitline.constant.EventStatus;
-import lombok.Data;
-
+import jakarta.persistence.*;
+import javax.persistence.*;
 import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.format.annotation.DateTimeFormat;
+import java.util.Objects;
 
-/**
- * packageName    : com.application.getinitline.domain
- * fileName       : Event
- * author         : NAHAEJUN
- * date           : 2025-02-26
- * description    :
- * ===========================================================
- * DATE              AUTHOR             NOTE
- * -----------------------------------------------------------
- * 2025-02-26        NAHAEJUN              최초생성
- */
-@Data
+@Getter
+@ToString
+@Table(indexes = {
+    @Index(columnList = "eventName"),
+    @Index(columnList = "eventStartDatetime"),
+    @Index(columnList = "eventEndDatetime"),
+    @Index(columnList = "createdAt"),
+    @Index(columnList = "modifiedAt")
+})
+@EntityListeners(AuditingEntityListener.class)
+@Entity
 public class Event {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private Long placeId;
+
+    @Setter
+    @ManyToOne(optional = false) // Notnull을 표현
+    private Place place;
+
+    @Setter
+    @Column(nullable = false)
     private String eventName;
+
+    @Setter
+    @Column(nullable = false, columnDefinition = "varchar(20) default 'OPENED'")
+    @Enumerated(EnumType.STRING)
     private EventStatus eventStatus;
+
+    @Setter
+    @Column(nullable = false, columnDefinition = "datetime")
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     private LocalDateTime eventStartDatetime;
+
+    @Setter
+    @Column(nullable = false, columnDefinition = "datetime")
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     private LocalDateTime eventEndDatetime;
+
+    @Setter
+    @Column(nullable = false, columnDefinition = "integer default 0")
     private Integer currentNumberOfPeople;
+
+    @Setter
+    @Column(nullable = false)
     private Integer capacity;
+
+
+    @Setter
     private String memo;
 
+
+    @Column(nullable = false, insertable = false, updatable = false,
+        columnDefinition = "datetime default CURRENT_TIMESTAMP")
+    @CreatedDate
     private LocalDateTime createdAt;
+
+    @Column(nullable = false, insertable = false, updatable = false,
+        columnDefinition = "datetime default CURRENT_TIMESTAMP on update CURRENT_TIMESTAMP")
+    @LastModifiedDate
     private LocalDateTime modifiedAt;
+
+
+    protected Event() {}
+
+    protected Event(
+        Place place,
+        String eventName,
+        EventStatus eventStatus,
+        LocalDateTime eventStartDatetime,
+        LocalDateTime eventEndDatetime,
+        Integer currentNumberOfPeople,
+        Integer capacity,
+        String memo
+    ) {
+        this.place = place;
+        this.eventName = eventName;
+        this.eventStatus = eventStatus;
+        this.eventStartDatetime = eventStartDatetime;
+        this.eventEndDatetime = eventEndDatetime;
+        this.currentNumberOfPeople = currentNumberOfPeople;
+        this.capacity = capacity;
+        this.memo = memo;
+    }
+
+    public static Event of(
+        Place place,
+        String eventName,
+        EventStatus eventStatus,
+        LocalDateTime eventStartDatetime,
+        LocalDateTime eventEndDatetime,
+        Integer currentNumberOfPeople,
+        Integer capacity,
+        String memo
+    ) {
+        return new Event(
+            place,
+            eventName,
+            eventStatus,
+            eventStartDatetime,
+            eventEndDatetime,
+            currentNumberOfPeople,
+            capacity,
+            memo
+        );
+    }
+
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (obj == null || getClass() != obj.getClass()) return false;
+        return id != null && id.equals(((Event) obj).getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(eventName, eventStartDatetime, eventEndDatetime, createdAt, modifiedAt);
+    }
+
 }

--- a/src/main/java/com/application/getinitline/domain/Place.java
+++ b/src/main/java/com/application/getinitline/domain/Place.java
@@ -1,33 +1,125 @@
 package com.application.getinitline.domain;
 
 import com.application.getinitline.constant.PlaceType;
-import lombok.Data;
-
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import java.time.LocalDateTime;
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Set;
 
-/**
- * packageName    : com.application.getinitline.domain
- * fileName       : Place
- * author         : NAHAEJUN
- * date           : 2025-02-26
- * description    :
- * ===========================================================
- * DATE              AUTHOR             NOTE
- * -----------------------------------------------------------
- * 2025-02-26        NAHAEJUN              최초생성
- */
-@Data
+@Getter
+@ToString
+@Table(indexes = {
+    @Index(columnList = "placeName"),
+    @Index(columnList = "address"),
+    @Index(columnList = "phoneNumber"),
+    @Index(columnList = "createdAt"),
+    @Index(columnList = "modifiedAt")
+})
+@EntityListeners(AuditingEntityListener.class)
+@Entity
 public class Place {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+
+    @Setter
+    @Column(nullable = false, columnDefinition = "varchar(20) default 'COMMON'")
+    @Enumerated(EnumType.STRING)
     private PlaceType placeType;
+
+    @Setter
+    @Column(nullable = false)
     private String placeName;
+
+    @Setter
+    @Column(nullable = false)
     private String address;
+
+    @Setter
+    @Column(nullable = false)
     private String phoneNumber;
 
+    @Setter
+    @Column(nullable = false, columnDefinition = "integer default 0")
     private Integer capacity;
+
+
+    @Setter
     private String memo;
 
+
+    @Column(nullable = false, insertable = false, updatable = false,
+        columnDefinition = "datetime default CURRENT_TIMESTAMP")
+    @CreatedDate
     private LocalDateTime createdAt;
+
+    @Column(nullable = false, insertable = false, updatable = false,
+        columnDefinition = "datetime default CURRENT_TIMESTAMP on update CURRENT_TIMESTAMP")
+    @LastModifiedDate
     private LocalDateTime modifiedAt;
+
+
+    @ToString.Exclude // 순환참조 방지를 위한 설정
+    @OrderBy("id")
+    @OneToMany(mappedBy = "place")
+    private final Set<Event> events = new LinkedHashSet<>();
+
+    @ToString.Exclude // 순환참조 방지를 위한 설정
+    @OrderBy("id")
+    @OneToMany(mappedBy = "place", cascade = CascadeType.REMOVE)
+    private final Set<AdminPlaceMap> adminPlaceMaps = new LinkedHashSet<>(); //set을 이용해 중복을 피할수있고, 순서 유지를 위해 LinkedHashSet 사용
+
+
+    protected Place() {
+    }
+
+    protected Place(
+        PlaceType placeType,
+        String placeName,
+        String address,
+        String phoneNumber,
+        Integer capacity,
+        String memo
+    ) {
+        this.placeType = placeType;
+        this.placeName = placeName;
+        this.address = address;
+        this.phoneNumber = phoneNumber;
+        this.capacity = capacity;
+        this.memo = memo;
+    }
+
+    public static Place of(
+        PlaceType placeType,
+        String placeName,
+        String address,
+        String phoneNumber,
+        Integer capacity,
+        String memo
+    ) {
+        return new Place(placeType, placeName, address, phoneNumber, capacity, memo);
+    }
+
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (obj == null || getClass() != obj.getClass()) return false;
+        return id != null && id.equals(((Place) obj).getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(placeName, address, phoneNumber, createdAt, modifiedAt);
+    }
+
 }

--- a/src/main/java/com/application/getinitline/repository/EventRepository.java
+++ b/src/main/java/com/application/getinitline/repository/EventRepository.java
@@ -1,8 +1,14 @@
 package com.application.getinitline.repository;
 
 import com.application.getinitline.constant.EventStatus;
+import com.application.getinitline.domain.Event;
+import com.application.getinitline.domain.Place;
 import com.application.getinitline.dto.EventDTO;
+import org.hibernate.query.Page;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 
+import java.awt.print.Pageable;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -18,18 +24,19 @@ import java.util.Optional;
  * -----------------------------------------------------------
  * 2025-03-26        NAHAEJUN              최초생성
  */
-public interface EventRepository {
-    // TODO , 인스턴스 생성시 편의를 위함
-    default List<EventDTO> findEvents(
-            Long placeId,
-            String eventName,
-            EventStatus eventStatus,
-            LocalDateTime eventStartTime,
-            LocalDateTime EndStartTime
-    ){return List.of();}
+public interface EventRepository extends
+    JpaRepository<Event, Long>,
+    QuerydslPredicateExecutor<Event>{
 
-    default Optional<EventDTO> findEvent(Long eventId){return Optional.empty();}
-    default boolean insertEvent(EventDTO eventDTO){return true;}
-    default boolean updateEvent(Long eventId, EventDTO dto){return true;}
-    default boolean removeEvent(Long eventId){return true;}
+//    Page<Event> findByPlace(Place place, Pageable pageable);
+//
+//    @Override
+//    default void customize(QuerydslBindings bindings, QEvent root) {
+//        bindings.excludeUnlistedProperties(true);
+//        bindings.including(root.place.placeName, root.eventName, root.eventStatus, root.eventStartDatetime, root.eventEndDatetime);
+//        bindings.bind(root.place.placeName).as("placeName").first(StringExpression::containsIgnoreCase);
+//        bindings.bind(root.eventName).first(StringExpression::containsIgnoreCase);
+//        bindings.bind(root.eventStartDatetime).first(ComparableExpression::goe);
+//        bindings.bind(root.eventEndDatetime).first(ComparableExpression::loe);
+//    }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -21,3 +21,27 @@ spring.mvc.view.suffix=.html
 #spring.config.activate.on-profile=
 #
 #spring.mvc.converters.preferred-json-mapper=jackson
+
+#DataBase
+spring.jpa.defer-datasource-initialization=true
+#spring.jpa.properties.hibernate.connection.provider_disables_autocommit_detection=true
+#\uC77C\uBC18\uC801\uC73C\uB85C \uC774\uC635\uC158\uC740 \uC0AC\uC6A9\uD558\uC9C0 \uC54A\uC74C
+spring.jpa.hibernate.ddl-auto=create
+spring.jpa.show-sql=true
+#DevTools\uC5D0\uC11C\uB294 default\uAC12\uC774 \uB2E4\uB974\uB2E4.
+spring.jpa.properties.hibernate.format_sql=true
+# \uC870\uC778\uD560\uB54C n \uD50C\uB7EC\uC2A4 1 \uCFFC\uB9AC \uBB38\uC81C
+# \uC5EC\uB7EC\uAC1C\uC758 select \uCFFC\uB9AC\uAC00 \uB0A0\uC544\uAC83\uC744 in\uCFFC\uB9AC\uB85C \uBAA8\uC740\uB2E4.
+# where in \uC774\uB807\uAC8C in\uC73C\uB85C \uD574\uC11C \uC544\uC774\uB514\uB97C in\uCFFC\uB9AC \uC548\uC73C\uB85C \uBAA8\uC544\uC8FC\uBA74 \uCFFC\uB9AC \uC0AC\uC774\uC988\uAC00 \uC904\uC5B4\uB4E4\uACE0 , \uADF8\uAC78 \uC9C0\uAE08 100\uAC1C\uB85C \uC81C\uD55C \uB454\uAC70\uB2E4.
+# in\uCFFC\uB9AC \uC548\uC5D0 \uCFFC\uB9AC\uB97C 100\uAC1C \uC774\uC0C1 \uB118\uC9C0 \uC54A\uACA0\uB2E4\uB294 \uB73B\uC774\uB2E4. \uD06C\uAC8C \uD558\uB294\uAC74 \uC88B\uC9C0\uC54A\uC74C (\uBD80\uB2F4\uB418\uB294 \uCFFC\uB9AC\uAC00 \uB428)
+spring.jpa.properties.hibernate.default_batch_fetch_size=100
+spring.h2.console.enabled=false
+#spring.datasource.url=jdbc:mysql://192.168.111.200:3306/userDB
+spring.datasource.url=jdbc:mysql://192.168.111.200:3306/userDB
+spring.datasource.username=dev01
+spring.datasource.password=1234
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+#inmemory \uAE30\uB2A5\uC774 \uC11C\uBE44\uC2A4\uC5D0\uB3C4 \uC801\uC6A9\uB428
+spring.sql.init.mode=always
+
+


### PR DESCRIPTION
- @Entity 설정 추가 및 JPA 관련 어노테이션 적용
- Equals, HashCode, toString 메서드 구현으로 엔티티 비교 및 로깅 개선
- Auditing 관련 필드(createdAt, modifiedAt) 및 Listener 설정 추가
- Event, Place, Admin 등 연관 관계 매핑 설정 완료 (ManyToOne, OneToMany)
- 데이터베이스 MySQL 설정 변경 및 필요한 의존성 추가
- JpaRepository 및 QueryDSL 지원 추가